### PR TITLE
Update ffmpeg.py to remove 1 px long line on uncaptioned videos

### DIFF
--- a/src/processing/ffmpeg.py
+++ b/src/processing/ffmpeg.py
@@ -943,6 +943,7 @@ async def crop(file, w, h, x, y):
 
 async def trim_top(file, trim_size):
     mt = await mediatype(file)
+    trim_size = trim_size + 1
     exts = {
         "VIDEO": "mp4",
         "GIF": "mp4",


### PR DESCRIPTION
there is a 1 pixel white line on uncaption commands on the top of videos so this should usually cover it